### PR TITLE
DE6903-sh-app-cta-bug

### DIFF
--- a/src/components/shared-header/global-nav/global-nav.scss
+++ b/src/components/shared-header/global-nav/global-nav.scss
@@ -6,7 +6,7 @@ header {
   z-index: 2;
 
   @supports (position: sticky) {
-    position: fixed;
+    position: sticky;
   }
 
   > div {

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
   </head>
   <body>
 
-    <div class="shared-header-skeleton">
+    <div class="shared-header-skeleton" style="position: sticky; top:0;">
       <shared-header env="int"></shared-header>
     </div>
 


### PR DESCRIPTION
 Adds sticky position to header

---

 Note: Position sticky on shared-header will only work if shared-header-skeleton also has position sticky. A PR for this exists [here](https://github.com/crdschurch/crds-styles/pull/396). Once this is ready to implement, remove inline styles for shared-header-skeleton in index.html
 