### PR TITLE
Feature/us18564 optional label

### DIFF
--- a/src/components/crds-media-card/crds-media-card.stories.js
+++ b/src/components/crds-media-card/crds-media-card.stories.js
@@ -43,8 +43,8 @@ stories
       </p>`
     );
     const url = text('url', '#');
-    const contentTypeOptions = ['article', 'video', 'episode', 'song']
-    const contentType = select('Content Type', contentTypeOptions, 'article')
+    const contentTypeOptions = ['article', 'video', 'episode', 'song', null];
+    const contentType = select('Content Type', contentTypeOptions, 'article');
 
     return `
     <div style="width: 1000px; display: flex;">

--- a/src/components/crds-media-card/layouts/crds-default-card/crds-default-card.scss
+++ b/src/components/crds-media-card/layouts/crds-default-card/crds-default-card.scss
@@ -39,7 +39,7 @@
   max-height: 28px;
 
   .card-stamp {
-    margin: 0 0.5rem 0 0.25rem;
+    margin: 0 0 0 0.25rem;
   }
 }
 

--- a/src/components/crds-media-card/layouts/crds-default-card/crds-default-card.tsx
+++ b/src/components/crds-media-card/layouts/crds-default-card/crds-default-card.tsx
@@ -39,8 +39,8 @@ export class CrdsDefaultLayout {
           {imageSrc && <crds-image src={imageSrc} size="card" />}
           {icons[contentType] && (
             <div class="card-stamp-container">
-              <span class="card-stamp">{iconLabel}</span>
-              <crds-icon name={icons[contentType]} size={'15'} color={'white'} />
+              {iconLabel && <span class="card-stamp">{iconLabel}</span>}
+              <crds-icon style={{ paddingLeft: '0.25rem' }} name={icons[contentType]} size={'15'} color={'white'} />
             </div>
           )}
           {thumbnailSrc && (


### PR DESCRIPTION
### Problem
There is no option to create a media-card without an `IconLabel` or card stamp.

### Solution
Conditionally render `IconLabel` and allow card stamp to only show if `contentType` is passed as a prop